### PR TITLE
fix: append author name for C4 diagrams

### DIFF
--- a/Engineering/C4 diagrams.md
+++ b/Engineering/C4 diagrams.md
@@ -1,5 +1,6 @@
 ---
 tags: engineering, architecture, diagram
+author: Nguyen Xuan Anh
 ---
 
 # What are C4 diagrams?


### PR DESCRIPTION
#### What's this PR do?

This PR adds missing author metadata for the C4 diagram brainery note.