### PR TITLE
engineering: introductory articles on state machines

### DIFF
--- a/Engineering/State machines/Finite-state automata.md
+++ b/Engineering/State machines/Finite-state automata.md
@@ -21,7 +21,7 @@ State machines are definitely a step up from [[Algebraic data types]] as it solv
 
 Luckily, we can solve this with Harel [[Statecharts]]; you may know and refer to them as [UML state machines](https://en.wikipedia.org/wiki/UML_state_machine) In essence, statecharts are a combination of [Mealy machines](https://en.wikipedia.org/wiki/Mealy_machine) and [Moore machines](https://en.wikipedia.org/wiki/Moore_machine).
 
-Although it is conventional to think $\delta$ as a [partial function](https://en.wikipedia.org/wiki/Partial_function), i.e: $\delta(s,x)$, the operator precedence relative to the data is, almost in all cases, left associative. This means asynchronously *parallel* application of the partial function will result in broken logic, that is unless all events are completely valid and it is possible combine partial and illegal transitions of states into a proper finite state (theory to apply for [[TimescaleDB]] [continuous aggregates](https://docs.timescale.com/timescaledb/latest/how-to-guides/continuous-aggregates/)) c
+Although it is conventional to think $\delta$ as a [partial function](https://en.wikipedia.org/wiki/Partial_function), i.e: $\delta(s,x)$, the operator precedence relative to the data is, almost in all cases, left associative. This means asynchronously *parallel* application of the partial function will result in broken logic, that is unless all events are completely valid and it is possible combine partial and illegal transitions of states into a proper finite state (theory to apply for [[TimescaleDB]] [continuous aggregates](https://docs.timescale.com/timescaledb/latest/how-to-guides/continuous-aggregates/)).
 
 # References
 - https://en.wikipedia.org/wiki/Finite-state_machine

--- a/Engineering/State machines/Finite-state automata.md
+++ b/Engineering/State machines/Finite-state automata.md
@@ -3,10 +3,10 @@ tags: engineering, state, diagram, machines
 author: Nguyen Xuan Anh
 ---
 
-# What are finite state automata?
+## What are finite state automata?
 A **finite state automaton (FSM)** (**FSA**, plural: automata), or better known as a state machine, is a mathematical model of with a constraint such that the abstract machine can be only and exactly be one of a finite number of states at any point in time. Finite state here is typically represented as a string or equivalent enumeration.
 
-# Mathematical Model
+## Mathematical Model
 A _deterministic finite-state machine_ or _deterministic finite-state acceptor_ is a [quintuple](https://en.wikipedia.org/wiki/Tuple "Tuple")
 $(\sum, S, s_0, \delta, F)$
 - $\sum$ is the input alphabet (a finite non-empty set of symbols) -> our events
@@ -16,13 +16,13 @@ $(\sum, S, s_0, \delta, F)$
 	- in a [nondeterministic finite automaton](https://en.wikipedia.org/wiki/Nondeterministic_finite_automaton "Nondeterministic finite automaton") it would be $\delta: S \times \sum \rightarrow P(S)$
 -  $F$ is the set of final states, a (possibly empty) subset of $S$
 
-# Coming from Algebraic Data Types
+## Coming from Algebraic Data Types
 State machines are definitely a step up from [[Algebraic data types]] as it solves type/event explosion with nested [[Sum types]], however, it still has some limitations given that they can only solve a very flat domain problem. This is because the more nested states you want to represent in a finite state machine, the more combinatorially complex it becomes, causing a [[State explosion]].
 
 Luckily, we can solve this with Harel [[Statecharts]]; you may know and refer to them as [UML state machines](https://en.wikipedia.org/wiki/UML_state_machine) In essence, statecharts are a combination of [Mealy machines](https://en.wikipedia.org/wiki/Mealy_machine) and [Moore machines](https://en.wikipedia.org/wiki/Moore_machine).
 
 Although it is conventional to think $\delta$ as a [partial function](https://en.wikipedia.org/wiki/Partial_function), i.e: $\delta(s,x)$, the operator precedence relative to the data is, almost in all cases, left associative. This means asynchronously *parallel* application of the partial function will result in broken logic, that is unless all events are completely valid and it is possible combine partial and illegal transitions of states into a proper finite state (theory to apply for [[TimescaleDB]] [continuous aggregates](https://docs.timescale.com/timescaledb/latest/how-to-guides/continuous-aggregates/)).
 
-# References
+#### References
 - https://en.wikipedia.org/wiki/Finite-state_machine
 - https://blog.honosoft.com/2019/10/31/partial-state-machine/

--- a/Engineering/State machines/Finite-state automata.md
+++ b/Engineering/State machines/Finite-state automata.md
@@ -1,0 +1,28 @@
+---
+tags: engineering, state, diagram, machines
+author: Nguyen Xuan Anh
+---
+
+# What are finite state automata?
+A **finite state automaton (FSM)** (**FSA**, plural: automata), or better known as a state machine, is a mathematical model of with a constraint such that the abstract machine can be only and exactly be one of a finite number of states at any point in time. Finite state here is typically represented as a string or equivalent enumeration.
+
+# Mathematical Model
+A _deterministic finite-state machine_ or _deterministic finite-state acceptor_ is a [quintuple](https://en.wikipedia.org/wiki/Tuple "Tuple")
+$(\sum, S, s_0, \delta, F)$
+- $\sum$ is the input alphabet (a finite non-empty set of symbols) -> our events
+- $S$ is a finite non-empty set of states
+- $s_0$ is an initial state, an element of $S$
+- $\delta$ is the state-transition function: $\delta: S \times \sum \rightarrow S$
+	- in a [nondeterministic finite automaton](https://en.wikipedia.org/wiki/Nondeterministic_finite_automaton "Nondeterministic finite automaton") it would be $\delta: S \times \sum \rightarrow P(S)$
+-  $F$ is the set of final states, a (possibly empty) subset of $S$
+
+# Coming from Algebraic Data Types
+State machines are definitely a step up from [[Algebraic data types]] as it solves type/event explosion with nested [[Sum types]], however, it still has some limitations given that they can only solve a very flat domain problem. This is because the more nested states you want to represent in a finite state machine, the more combinatorially complex it becomes, causing a [[State explosion]].
+
+Luckily, we can solve this with Harel [[Statecharts]]; you may know and refer to them as [UML state machines](https://en.wikipedia.org/wiki/UML_state_machine) In essence, statecharts are a combination of [Mealy machines](https://en.wikipedia.org/wiki/Mealy_machine) and [Moore machines](https://en.wikipedia.org/wiki/Moore_machine).
+
+Although it is conventional to think $\delta$ as a [partial function](https://en.wikipedia.org/wiki/Partial_function), i.e: $\delta(s,x)$, the operator precedence relative to the data is, almost in all cases, left associative. This means asynchronously *parallel* application of the partial function will result in broken logic, that is unless all events are completely valid and it is possible combine partial and illegal transitions of states into a proper finite state (theory to apply for [[TimescaleDB]] [continuous aggregates](https://docs.timescale.com/timescaledb/latest/how-to-guides/continuous-aggregates/)) c
+
+# References
+- https://en.wikipedia.org/wiki/Finite-state_machine
+- https://blog.honosoft.com/2019/10/31/partial-state-machine/

--- a/Engineering/State machines/Reducers.md
+++ b/Engineering/State machines/Reducers.md
@@ -5,7 +5,7 @@ author: Nguyen Xuan Anh
 
 *This note refers to frontend reducers, and not to be confused with other reducers like from MapReduce.*
 
-# Prior art
+## Prior art
 
 Although reducers can be represented as a simple switch case of events, the mainstream application of reducers happens either in React's `useReducer` hook, or on Redux in which many of its qualities were motivated from Facebook's Flux architecture.
 
@@ -13,7 +13,7 @@ Although reducers can be represented as a simple switch case of events, the main
 
 Along with Elm, the composition of these architectures are very similar to union types (called custom types in Elm) in algebraic data types (ADTs). Unlike normal state machines, we don't encode state in our ADT and assume the initial state of the reducer is the only state.
 
-# As a state machine
+## As a state machine
 
 With regard to state management, reducers are essentially single state machines. Although dispatched events doesn't change the initial state, we expect the events to progress the data "context" of the machine. We can refer this as non-deterministic states. For instance, the non-deterministic state of the counter is the incremented `value`:
 
@@ -46,7 +46,7 @@ export let transition = (state, event) =>
   }
 ```
 
-## Tradeoffs vs a regular state machine
+### Tradeoffs vs a regular state machine
 
 Here a reducer  has no concept of a "finite" state here, such that state can be represented finitely with a string. This is an inherent tradeoff that also gives us a useful advantage. Assuming the "context" or non-deterministic state of the reducer uses addition/multiplication, the reducer itself would follow the associative law. This gives us the benefit of converting any reducer that follows the associative law to parallelize its operations.
 

--- a/Engineering/State machines/Reducers.md
+++ b/Engineering/State machines/Reducers.md
@@ -1,0 +1,59 @@
+---
+tags: engineering, state, domain
+author: Nguyen Xuan Anh
+---
+
+*This note refers to frontend reducers, and not to be confused with other reducers like from MapReduce.*
+
+# Prior art
+
+Although reducers can be represented as a simple switch case of events, the mainstream application of reducers happens either in React's `useReducer` hook, or on Redux in which many of its qualities were motivated from Facebook's Flux architecture.
+
+![Flux architecture](https://facebook.github.io/flux/img/overview/flux-simple-f8-diagram-with-client-action-1300w.png)
+
+Along with Elm, the composition of these architectures are very similar to union types (called custom types in Elm) in algebraic data types (ADTs). Unlike normal state machines, we don't encode state in our ADT and assume the initial state of the reducer is the only state.
+
+# As a state machine
+
+With regard to state management, reducers are essentially single state machines. Although dispatched events doesn't change the initial state, we expect the events to progress the data "context" of the machine. We can refer this as non-deterministic states. For instance, the non-deterministic state of the counter is the incremented `value`:
+
+![Counter reducer state machine](https://erikras.com/_next/image?url=%2Fimages%2Fsingle-state-machine.png&w=1920&q=75)
+
+We will use ReScript in our example to better represent our reducers as ADTs. In ReScript, the average reducer would look as such:
+
+```typescript
+type state = int
+type action = Increment | Decrement
+
+export let transition = (state, action) =>
+  switch (event) {
+    | Increment => state + 1
+    | Decrement => state - 1
+  }
+```
+
+Its composition is very similar when we encode state and convert it into a state machine:
+
+```typescript
+type state = Idle(int)
+type event = Increment | Decrement
+
+export let initial = Idle(0)
+export let transition = (state, event) =>
+  switch (state, event) {
+    | (Idle(value), Increment) => Idle(value + 1)
+    | (Idle(value), Decrement) => Idle(value - 1)
+  }
+```
+
+## Tradeoffs vs a regular state machine
+
+Here a reducer  has no concept of a "finite" state here, such that state can be represented finitely with a string. This is an inherent tradeoff that also gives us a useful advantage. Assuming the "context" or non-deterministic state of the reducer uses addition/multiplication, the reducer itself would follow the associative law. This gives us the benefit of converting any reducer that follows the associative law to parallelize its operations.
+
+#### Reference
+- https://en.wikipedia.org/wiki/Union_(set_theory)
+- https://guide.elm-lang.org/types/custom_types.html
+- https://erikras.com/blog/reducer-single-state-machine
+- https://facebook.github.io/flux/
+- https://redux.js.org/understanding/history-and-design/prior-art
+- https://github.com/jas-chen/rx-redux

--- a/Engineering/State machines/State explosion.md
+++ b/Engineering/State machines/State explosion.md
@@ -1,0 +1,35 @@
+---
+tags: engineering, state, diagram
+author: Nguyen Xuan Anh
+---
+
+# What is state explosion?
+The main problem that’s stopping widespread usage of state machines is the fact that beyond very simple examples, state machines often end up with numerous states, a lot of them with identical transitions. [[Statecharts]] solve this _state explosion_ problem.
+
+![State explosion](https://statecharts.dev/valid-invalid-enabled-disabled-changed-unchanged.svg)
+
+Similar to [nested positive if statements](https://stackoverflow.com/questions/4369822/early-returns-vs-nested-positive-if-statements), state explosions represent combinatorially complex growth of states. This can also be seen with nested [[Product types]].
+
+# How do statecharts solve this problem?
+
+## Parallel states
+
+Separating nested finite states into individual states that can be progressed with the same or different events:
+
+![Parallel state machine](https://statecharts.dev/valid-invalid-enabled-disabled-changed-unchanged-parallel.svg)
+
+## Hierarchical states
+
+Reorganizing nested finite states into a hierarchy, such that the finite state of a child state machine is dependent on the transition between the parent and child machines:
+
+![Hierarchical state machines](https://statecharts.dev/valid-invalid-enabled-disabled-changed-unchanged-parallel-hierarchy.svg)
+
+## Guards (conditions)
+
+Guards here serve as a pre-condition to a transition, which essentially prevents a transition from occurring based on a condition:
+
+![[Pasted image 20220522163854.png]]
+![Guard conditions](https://statecharts.dev/valid-invalid-enabled-disabled-changed-unchanged-parallel-guarded.svg)
+
+#### Reference
+- https://statecharts.dev/state-machine-state-explosion.html

--- a/Engineering/State machines/State explosion.md
+++ b/Engineering/State machines/State explosion.md
@@ -3,28 +3,28 @@ tags: engineering, state, diagram
 author: Nguyen Xuan Anh
 ---
 
-# What is state explosion?
+## What is state explosion?
 The main problem that’s stopping widespread usage of state machines is the fact that beyond very simple examples, state machines often end up with numerous states, a lot of them with identical transitions. [[Statecharts]] solve this _state explosion_ problem.
 
 ![State explosion](https://statecharts.dev/valid-invalid-enabled-disabled-changed-unchanged.svg)
 
 Similar to [nested positive if statements](https://stackoverflow.com/questions/4369822/early-returns-vs-nested-positive-if-statements), state explosions represent combinatorially complex growth of states. This can also be seen with nested [[Product types]].
 
-# How do statecharts solve this problem?
+## How do statecharts solve this problem?
 
-## Parallel states
+### Parallel states
 
 Separating nested finite states into individual states that can be progressed with the same or different events:
 
 ![Parallel state machine](https://statecharts.dev/valid-invalid-enabled-disabled-changed-unchanged-parallel.svg)
 
-## Hierarchical states
+### Hierarchical states
 
 Reorganizing nested finite states into a hierarchy, such that the finite state of a child state machine is dependent on the transition between the parent and child machines:
 
 ![Hierarchical state machines](https://statecharts.dev/valid-invalid-enabled-disabled-changed-unchanged-parallel-hierarchy.svg)
 
-## Guards (conditions)
+### Guards (conditions)
 
 Guards here serve as a pre-condition to a transition, which essentially prevents a transition from occurring based on a condition:
 


### PR DESCRIPTION
#### What's this PR do?

This PR adds a few introductory notes for state machines. Since the family topic on finite-state automata is quite large, this PR also creates a folder `State machine` to organize the notes there.

- [x] Add new folder `State machine`
- [x] Added note for finite-state automata
- [x] Added note for reducers
- [x] Added note for state explosion (introductory for statecharts)