### PR TITLE
engineering: finite-state transducers + mealy and moore machines

### DIFF
--- a/Engineering/Finite-state automata.md
+++ b/Engineering/Finite-state automata.md
@@ -8,25 +8,67 @@ author: Nguyen Xuan Anh
 A **finite state automaton (FSM)** (**FSA**, plural: automata), or better known as a state machine, is a mathematical model of with a constraint such that the abstract machine can be only and exactly be one of a finite number of states at any point in time. Finite state here is typically represented as a string or equivalent enumeration.
 
 ## Mathematical Model
+As per the general classification noted on the [Wikipedia page on finite-state machines](https://en.wikipedia.org/wiki/Finite-state_machine), deterministic finite-state machine has 5 main variables associated with its definition (a quintuple): $(\Sigma, S, s_0, \delta, F)$.
+- $\Sigma$ is the *input alphabet* (a finite non-empty set of symbols) -> our events;
+- $S$ is a finite non-empty set of states;
+- $s_0$ is an *initial state*, an element of $S$;
+- $\delta$ is the state-transition function: $\delta: S \times \Sigma \rightarrow S$; and
+- $F$ is the set of *final states*, a (possibly empty) subset of $S$.
 
-A _deterministic finite-state machine_ or _deterministic finite-state acceptor_ is a [quintuple](https://en.wikipedia.org/wiki/Tuple 'Tuple') $(\sum, S, s_0, \delta, F)$
+Given an initial state $s_0$, to transition our state to the next state, our transition would simply be:
+$$
+\delta: s_0 \times \Sigma \rightarrow S
+$$
+If we were to reach a final state starting from a known set of states, our transition would look like:
+$$
+\delta: S \times \Sigma \rightarrow F
+$$
+### Simplified meaning
+For our purposes, we just need to understand that a `transition` function takes a `state` and an `event` to move on to a **new** `state`. What type of state and what subset it belongs to is up to the developer's discretion.
 
-- $\sum$ is the input alphabet (a finite non-empty set of symbols) -> our events
-- $S$ is a finite non-empty set of states
-- $s_0$ is an initial state, an element of $S$
-- $\delta$ is the state-transition function: $\delta: S \times \sum \rightarrow S$
-  - in a [nondeterministic finite automaton](https://en.wikipedia.org/wiki/Nondeterministic_finite_automaton 'Nondeterministic finite automaton') it would be $\delta: S \times \sum \rightarrow P(S)$
-- $F$ is the set of final states, a (possibly empty) subset of $S$
+```typescript
+type State = string
+type Event = string
+
+const transition = (state: State, event: Event): State => ...
+```
 
 ## Coming from Algebraic Data Types
+If you're coming from algebraic data types (ADTs), you may have noticed that state machines are nested ADTs that encode states and events as data types. In this case, we take advantage of nesting or combining pairs of sum/union types (example in Rescript):
 
-State machines are definitely a step up from [[Algebraic data types]] as it solves type/event explosion with nested [[Sum types]], however, it still has some limitations given that they can only solve a very flat domain problem. This is because the more nested states you want to represent in a finite state machine, the more combinatorially complex it becomes, causing a [[State explosion]].
+```typescript
+type elapsed = float;
 
-Luckily, we can solve this with Harel [[Statecharts]]; you may know and refer to them as [UML state machines](https://en.wikipedia.org/wiki/UML_state_machine) In essence, statecharts are a combination of [Mealy machines](https://en.wikipedia.org/wiki/Mealy_machine) and [Moore machines](https://en.wikipedia.org/wiki/Moore_machine).
+type taskStatus =
+  | NotStarted
+  | Running(elapsed)
+  | Paused(elapsed)
+  | Done(elapsed);
 
-Although it is conventional to think $\delta$ as a [partial function](https://en.wikipedia.org/wiki/Partial_function), i.e: $\delta(s,x)$, the operator precedence relative to the data is, almost in all cases, left associative. This means asynchronously _parallel_ application of the partial function will result in broken logic, that is unless all events are completely valid and it is possible combine partial and illegal transitions of states into a proper finite state (theory to apply for [[TimescaleDB]] [continuous aggregates](https://docs.timescale.com/timescaledb/latest/how-to-guides/continuous-aggregates/)).
+type input =
+  | Start
+  | Pause
+  | Resume
+  | Finish
+  | Tick(elapsed);
 
-#### References
+let transition = (input, state) =>
+  switch (state, input) {
+  | (NotStarted, Start) => Running(0.0)
+  | (Running(elapsed), Pause) => Paused(elapsed)
+  | (Running(elapsed), Finish) => Done(elapsed)
+  | (Paused(elapsed), Resume) => Running(elapsed)
+  | (Paused(elapsed), Finish) => Done(elapsed)
+  | (Running(elapsed), Tick(tick)) => Running(elapsed +. tick)
+  | _ => state
+  };
+```
 
+## States and relevance in the *domain*
+In [[Domain Driven Design]] (DDD) and in [[Event storming]], there doesn't seem to be space for states in the domain. This is most likely because there is a separation of concern between the behavior of commands against what gets updated in the aggregate. DDD does allow classification of entities, such as classifying customer statuses, and these of course have business meaning. However, DDD doesn't specify any technical concerns such as the persistence of state or where a state transition should occur and what effects should happen.
+
+# References
 - https://en.wikipedia.org/wiki/Finite-state_machine
+- https://wickstrom.tech/finite-state-machines/2017/11/10/finite-state-machines-part-1-modeling-with-haskell.html
+- https://dev.to/margaretkrutikova/modelling-domain-with-state-machines-in-reasonml-n29
 - https://blog.honosoft.com/2019/10/31/partial-state-machine/

--- a/Engineering/Finite-state automata.md
+++ b/Engineering/Finite-state automata.md
@@ -3,8 +3,7 @@ tags: engineering, state, diagram, machines
 author: Nguyen Xuan Anh
 ---
 
-## What are finite state automata?
-
+## What are finite-state automata?
 A **finite state automaton (FSM)** (**FSA**, plural: automata), or better known as a state machine, is a mathematical model of with a constraint such that the abstract machine can be only and exactly be one of a finite number of states at any point in time. Finite state here is typically represented as a string or equivalent enumeration.
 
 ## Mathematical Model
@@ -41,25 +40,24 @@ type elapsed = float;
 
 type taskStatus =
   | NotStarted
-  | Running(elapsed)
-  | Paused(elapsed)
-  | Done(elapsed);
+  | Running
+  | Paused
+  | Done;
 
 type input =
   | Start
   | Pause
   | Resume
-  | Finish
-  | Tick(elapsed);
+  | Finish;
 
-let transition = (input, state) =>
+let transition = (state, input) =>
   switch (state, input) {
-  | (NotStarted, Start) => Running(0.0)
-  | (Running(elapsed), Pause) => Paused(elapsed)
-  | (Running(elapsed), Finish) => Done(elapsed)
-  | (Paused(elapsed), Resume) => Running(elapsed)
-  | (Paused(elapsed), Finish) => Done(elapsed)
-  | (Running(elapsed), Tick(tick)) => Running(elapsed +. tick)
+  | (NotStarted, Start) => Running
+  | (Running, Pause) => Paused
+  | (Running, Finish) => Done
+  | (Paused, Resume) => Running
+  | (Paused, Finish) => Done
+  | (Running, Tick) => Running
   | _ => state
   };
 ```

--- a/Engineering/Finite-state transducer.md
+++ b/Engineering/Finite-state transducer.md
@@ -90,6 +90,39 @@ function Counter() {
 }
 ```
 
+We can take our example from [[Finite-state automata]] and wrap it in a way that encapsulates both state, inputs and outputs (in Rescript):
+
+```typescript
+// elapsed represents our arbitrary output
+type elapsed = float;
+
+// elapsed here is used in a constructor as an arbitrary output
+type taskStatus =
+  | NotStarted
+  | Running(elapsed)
+  | Paused(elapsed)
+  | Done(elapsed);
+
+// elapsed here is used in a constructor as an arbitrary input
+type input =
+  | Start
+  | Pause
+  | Resume
+  | Finish
+  | Tick(elapsed);
+
+let transition = (state, input) =>
+  switch (state, input) {
+  | (NotStarted, Start) => Running(0.0)
+  | (Running(elapsed), Pause) => Paused(elapsed)
+  | (Running(elapsed), Finish) => Done(elapsed)
+  | (Paused(elapsed), Resume) => Running(elapsed)
+  | (Paused(elapsed), Finish) => Done(elapsed)
+  | (Running(elapsed), Tick(tick)) => Running(elapsed +. tick)
+  | _ => state
+  };
+```
+
 ## Reference
 - https://en.wikipedia.org/wiki/Turing_machine
 - https://t-pl.io/ddd-aggregates-processes-state-machines-and-transducers

--- a/Engineering/Finite-state transducer.md
+++ b/Engineering/Finite-state transducer.md
@@ -1,0 +1,100 @@
+---
+tags: engineering, state, diagram, machines, transducers
+author: Nguyen Xuan Anh
+---
+
+## What is finite-state transducer?
+
+It is essentially a [[Finite-state automata]] that has both inputs and outputs. In [Turing machines](https://en.wikipedia.org/wiki/Turing_machine), these inputs and outputs are referred to as 2 separate tapes:
+
+- **input tape**: a set of strings or related data.
+- **output tape**: a set of relations generated from the input tape.
+
+This differs from a finite-state automaton which only has 1 (input) tape.
+
+## Mathematical Model
+As per the general classification noted on [UC Davis outline on transducers](https://www.cs.ucdavis.edu/~rogaway/classes/120/spring13/eric-transducers) (formatted with similar variables to [[Finite-state automata]]s), a deterministic finite-state machine has 7 main variables associated with its definition (a septuple): ($\Sigma$, $S$, $\Gamma$, $\delta$, $\omega$, $s_0$, _$F$).
+- $\Sigma$ is the *input alphabet* (a finite non-empty set of symbols) -> our events;
+- $S$ is a finite non-empty set of states;
+- $\Gamma$ is the _output alphabet_;
+- $\delta$ is the state-transition function: $\delta: S \times \Sigma \rightarrow S$
+- $\omega$ is the output-transition function: $\omega: S \times \Sigma \rightarrow \Gamma$
+- $s_0$ is an *initial state*, an element of $S$;
+- $F$ is the set of _final states_ and is a subset of $S$; and
+- $\delta \subseteq S \times (\Sigma \cup \{\epsilon\}) \times (\Gamma \cup \{\epsilon\}) \times S$ (where ε is the [empty string](https://en.wikipedia.org/wiki/Empty_string "Empty string")) is the _transition relation_.
+
+Given any initial state in $s_0$, to transition our state to the next state with our output alphabet, our transition would be:
+$$
+\delta: s_0 \times \Sigma \rightarrow S
+$$
+$$
+\omega: s_0 \times \Sigma \rightarrow \Gamma
+$$
+$$
+\delta \subseteq s_0 \times (\Sigma \cup \{\epsilon\}) \times (\Gamma \cup \{\epsilon\}) \times S
+$$
+If we were to reach a final state starting from a known set of states, our transition would look pretty similar:
+$$
+\delta: S \times \Sigma \rightarrow F
+$$
+$$
+\omega: S \times \Sigma \rightarrow \Gamma
+$$
+$$
+\delta \subseteq S \times (\Sigma \cup \{\epsilon\}) \times (\Gamma \cup \{\epsilon\}) \times F
+$$
+
+Transducers that have a final state are used to recognize languages and have their use cases in [[Natural-Language Processing]].
+
+### Simplified meaning
+There's actually quite a few ways to write up a transducer, at it is not always simply a beefed-up state machine. To oversimplify, we'll model it closer to a regular state machine:
+
+```typescript
+type State = string
+type Input = string
+type Output = {...} //
+
+const transition = (state: State, input: Input): Output => ...
+```
+
+Outputs that are product types of itself and the next state of a transition is referred to as a [[Mealy machine]].
+
+## Examples of basic transducers
+Although we've mentioned before that [[Reducers]] are single state machines, the canonical method of creating one mentioned in [Redux](https://redux.js.org/) and [React](https://reactjs.org/docs/hooks-reference.html#usereducer) are pretty much transducers as they can return state or objects (as **notions** of outputs).
+
+```typescript
+// https://reactjs.org/docs/hooks-reference.html#usereducer
+// our outputs here is the { count: number } object
+const initialState = {count: 0};
+
+function reducer(state, action) {
+  switch (action.type) {
+    case 'increment':
+      return {count: state.count + 1};
+    case 'decrement':
+      return {count: state.count - 1};
+    default:
+      throw new Error();
+  }
+}
+
+function Counter() {
+  const [state, dispatch] = useReducer(reducer, initialState);
+  return (
+    <>
+      Count: {state.count}
+      <button onClick={() => dispatch({type: 'decrement'})}>-</button>
+      <button onClick={() => dispatch({type: 'increment'})}>+</button>
+    </>
+  );
+}
+```
+
+## Reference
+- https://en.wikipedia.org/wiki/Turing_machine
+- https://t-pl.io/ddd-aggregates-processes-state-machines-and-transducers
+- https://en.wikipedia.org/wiki/Finite-state_transducer
+- https://reactjs.org/docs/hooks-reference.html#usereducer
+- https://www.cs.ucdavis.edu/~rogaway/classes/120/spring13/eric-transducers
+- https://dl.acm.org/doi/10.5555/972695.972698
+- https://web.stanford.edu/~laurik/publications/ciaa-2000/fst-in-nlp/fst-in-nlp.html

--- a/Engineering/Mealy machine.md
+++ b/Engineering/Mealy machine.md
@@ -32,6 +32,40 @@ $$
 \omega: s_0 \times \Sigma \rightarrow \Gamma
 $$
 
+## Examples of basic Mealy machines
+
+Our example from [[Finite-state transducer]]s fits perfectly here as our transition and output function are coalesced as a single function.
+
+```typescript
+// expiry represents our arbitrary output (in seconds)
+type expiry = float;
+
+// expiry here is used in a constructor as an arbitrary output
+type trafficLightStatus =
+  | Red(expiry)
+  | Amber(expiry)
+  | Green(expiry)
+  | FlashingRed(expiry)
+
+// elapsed here is used in a constructor as an arbitrary input
+type input =
+  | ExpireTime
+  | Error
+  | Restart
+
+let transition = (state, input) =>
+  switch (state, input) {
+  | (Red(expiry), ExpireTime) => Green(60.0)
+  | (Red(expiry), Error) => FlashingRed(30.0)
+  | (Green(expiry), ExpireTime) => Amber(60.0)
+  | (Green(expiry), Error) => FlashingRed(30.0)
+  | (Amber(expiry), ExpireTime) => Red(60.0)
+  | (Amber(expiry), Error) => FlashingRed(30.0)
+  | (FlashingRed(expiry), Restart) => Red(60.0)
+  | _ => state
+  };
+```
+
 ## Differences between
 
 ### With formal [[Finite-state transducer]]s

--- a/Engineering/Mealy machine.md
+++ b/Engineering/Mealy machine.md
@@ -1,0 +1,50 @@
+---
+tags: engineering, state, diagram, machines
+author: Nguyen Xuan Anh
+---
+
+## What is a Mealy machine?
+A Mealy machine is a [[Finite-state automata]] where the output values are determined by its current state and current inputs. It is the closest definition to a deterministic [[Finite-state transducer]].
+
+![Mealy Machine](https://d8it4huxumps7.cloudfront.net/uploads/images/61d43f837b738_mealy_machines_characteristics.jpg)
+
+## Mathematical Model
+As per the general classification noted on [UC Davis outline on transducers](https://www.cs.ucdavis.edu/~rogaway/classes/120/spring13/eric-transducers) (formatted with similar variables to [[Finite-state automata]]s), a deterministic Mealy machine has 6 main variables associated with its definition (a sextuple): ($\Sigma$, $S$, $\Gamma$, $\delta$, $\omega$, $s_0$).
+- $\Sigma$ is the *input alphabet* (a finite non-empty set of symbols) -> our events;
+- $S$ is a finite non-empty set of states;
+- $\Gamma$ is the _output alphabet_;
+- $\delta$ is the state-transition function: $\delta: S \times \Sigma \rightarrow S$
+- $\omega$ is the output-transition function: $\omega: S \times \Sigma \rightarrow \Gamma$
+- $s_0$ is an *initial state*, an element of $S$; and
+- $\delta \subseteq S \times (\Sigma \cup \{\epsilon\}) \times (\Gamma \cup \{\epsilon\}) \times S$ (where ε is the [empty string](https://en.wikipedia.org/wiki/Empty_string "Empty string")) is the _transition relation_.
+
+Some formulations also allow transition and output functions to be combined as a single function:
+
+$$
+\delta: S \times \Sigma \rightarrow S \times \Gamma
+$$
+
+Given any initial state in $s_0$, to transition our state to the next state with our output alphabet, our transition would be:
+$$
+\delta: s_0 \times \Sigma \rightarrow S
+$$
+$$
+\omega: s_0 \times \Sigma \rightarrow \Gamma
+$$
+
+## Differences between
+
+### With formal [[Finite-state transducer]]s
+
+Mealy machines are a type of generator and are not used in processing language. As such, they do not have a concept of a final state.
+
+### With [[Moore Machine]]s
+
+oth Mealy and Moore machines are generator-type state machines and can be used to parse [regular language](https://en.wikipedia.org/wiki/Regular_language). The outputs on a Mealy machine depend on **both the state and inputs**, whereas a Moore machine have their outputs **synchronously change with the state.**
+
+> Every Moore machine can be converted to a Mealy machine and every Mealy machine can be converted to a Moore machine. Moore machine and Mealy machine are equivalent.
+
+## Reference
+- https://en.wikipedia.org/wiki/Mealy_machine
+- https://www.cs.ucdavis.edu/~rogaway/classes/120/spring13/eric-transducers
+- https://unstop.com/blog/difference-between-mealy-and-moore-machine

--- a/Engineering/Moore machine.md
+++ b/Engineering/Moore machine.md
@@ -3,8 +3,6 @@ tags: engineering, state, diagram, machines
 author: Nguyen Xuan Anh
 ---
 
-# Moore machine
-
 ## What is a Moore machine?
 A Moore machine is a [[Finite-state automata]] where the output values are determined by only its current state. Moore machines are a restricted type of a [[Finite-state transducer]].
 
@@ -27,6 +25,46 @@ $$
 $$
 \omega: s_0 \rightarrow \Gamma
 $$
+
+## Examples of basic Moore machines
+
+Unlike a Mealy machine, we can't coalesce the transition and output functions together as a single transition function. The behavior of the output function is **synchronous** to the state change. As such, we end up with something like this (in Rescript):
+
+```typescript
+type trafficLightStatus =
+  | Red
+  | Amber
+  | Green
+  | FlashingRed
+
+type input =
+  | ExpireTime
+  | Error
+  | Restart
+
+
+type outputFn = (state) =>
+  switch (state) {
+  |  Red => (Red, 60.0)
+  |  Green => (Green, 60.0)
+  |  Amber => (Amber, 60.0)
+  |  FlashingRed => (FlashingRed, 30.0)
+  }
+
+let transitionFn = (state, input) =>
+  switch (state, input) {
+  | (Red, ExpireTime) => Green(60.0)
+  | (Red, Error) => FlashingRed(30.0)
+  | (Green, ExpireTime) => Amber(60.0)
+  | (Green, Error) => FlashingRed(30.0)
+  | (Amber, ExpireTime) => Red(60.0)
+  | (Amber, Error) => FlashingRed(30.0)
+  | (FlashingRed, Restart) => Red(60.0)
+  | _ => state
+  };
+
+let output = outputFn(transitionFn(Red, ExpireTime)) // (Green, 60.0)
+```
 
 ## Differences between
 

--- a/Engineering/Moore machine.md
+++ b/Engineering/Moore machine.md
@@ -1,0 +1,46 @@
+---
+tags: engineering, state, diagram, machines
+author: Nguyen Xuan Anh
+---
+
+# Moore machine
+
+## What is a Moore machine?
+A Moore machine is a [[Finite-state automata]] where the output values are determined by only its current state. Moore machines are a restricted type of a [[Finite-state transducer]].
+
+![Moore Machine](https://d8it4huxumps7.cloudfront.net/uploads/images/61d43f4652280_block_diagram_of_moore_machine.jpg)
+
+## Mathematical Model
+As per the general classification noted on [UC Davis outline on transducers](https://www.cs.ucdavis.edu/~rogaway/classes/120/spring13/eric-transducers) (formatted with similar variables to [[Finite-state automata]]s), a deterministic Moore machine has 6 main variables associated with its definition (a sextuple): ($\Sigma$, $S$, $\Gamma$, $\delta$, $\omega$, $s_0$).
+- $\Sigma$ is the *input alphabet* (a finite non-empty set of symbols) -> our events;
+- $S$ is a finite non-empty set of states;
+- $\Gamma$ is the _output alphabet_;
+- $\delta$ is the state-transition function: $\delta: S \times \Sigma \rightarrow S$
+- $\omega$ is the output-transition function: $\omega: S \rightarrow \Gamma$
+- $s_0$ is an *initial state*, an element of $S$; and
+- $\delta \subseteq S \times (\Sigma \cup \{\epsilon\}) \times (\Gamma \cup \{\epsilon\}) \times S$ (where ε is the [empty string](https://en.wikipedia.org/wiki/Empty_string "Empty string")) is the _transition relation_.
+
+Given any initial state in $s_0$, to transition our state to the next state with our output alphabet, our transition would be:
+$$
+\delta: s_0 \times \Sigma \rightarrow S
+$$
+$$
+\omega: s_0 \rightarrow \Gamma
+$$
+
+## Differences between
+
+### With formal [[Finite-state transducer]]s
+
+Moore machines are a type of generator and are not used in processing natural language. As such, they do not have a concept of a final state.
+
+### With [[Mealy Machine]]s
+
+Both Mealy and Moore machines are generator-type state machines and can be used to parse [regular language](https://en.wikipedia.org/wiki/Regular_language). The outputs on a Mealy machine depend on **both the state and inputs**, whereas a Moore machine have their outputs **synchronously change with the state.**
+
+> Every Moore machine can be converted to a Mealy machine and every Mealy machine can be converted to a Moore machine. Moore machine and Mealy machine are equivalent.
+
+## Reference
+- https://en.wikipedia.org/wiki/Mealy_machine
+- https://www.cs.ucdavis.edu/~rogaway/classes/120/spring13/eric-transducers
+- https://unstop.com/blog/difference-between-mealy-and-moore-machine

--- a/Engineering/Reducers.md
+++ b/Engineering/Reducers.md
@@ -26,7 +26,7 @@ type state = int
 type action = Increment | Decrement
 
 export let transition = (state, action) =>
-  switch (event) {
+  switch (action) {
     | Increment => state + 1
     | Decrement => state - 1
   }


### PR DESCRIPTION
#### What's this PR do?

**Changes**
- [x] Fixes meaning by fixing syntax error in Reducers note
- [x] Updates Finite-state automata to remove jargon and update mathematical model symbols to be relatable to other notes on state machines

**Additions**
- [x] Adds an entry on Finite-state transducers
- [x] Adds an entry on Moore machines
- [x] Adds an entry on Mealy machines 