### PR TITLE
chore: fix typos

### DIFF
--- a/Engineering/Frontend/Build polymorphic React components with Typescript.md
+++ b/Engineering/Frontend/Build polymorphic React components with Typescript.md
@@ -204,8 +204,8 @@ type PropWithAs<C extends React.ElementType, P = {}> = P & AsProp<C>
 export type PolymorphicComponentProps<
   C extends React.ElementType,
   Props = {} // adding one more generic type
-> = PropWithAs &
-  Omit<React.ComponentPropsWithoutRef<C>, keyof PropWithAs>;
+> = PropWithAs<C, Props> &
+  Omit<React.ComponentPropsWithoutRef<C>, keyof PropWithAs<C, Props>>;
 
 ```
 


### PR DESCRIPTION
#### What's this PR do?

- [x] Fix typos: `PropWithAs` -> `PropWithAs<C, Props>`


