### PR TITLE
docs: add dataview reports for brainery + fleeting notes

### DIFF
--- a/Blockchain/Anchor framework.md
+++ b/Blockchain/Anchor framework.md
@@ -1,6 +1,7 @@
 ---
 tags: blockchain, solana, anchor, tutorial
 author: Pham Ngoc Thanh
+date: 2022-07-01
 ---
 
 This article features a short tutorial to start smart contract development on Solana using Anchor framework. Before you get started, we assume you already had the experience with:

--- a/Blockchain/Blockchain Bridge.md
+++ b/Blockchain/Blockchain Bridge.md
@@ -1,6 +1,7 @@
 ---
 tags: blockchain, blockchain-bridge
 author: Pham Ngoc Thanh
+date: 2022-06-21
 ---
 
 ![](https://blockruption.com/wp-content/uploads/2019/04/blockruption-blockchain-300h.png)

--- a/Blockchain/Foundational topics/Blocks.md
+++ b/Blockchain/Foundational topics/Blocks.md
@@ -1,5 +1,5 @@
 ---
-tags: blockchain, foundational topics
+tags: blockchain, foundational-topics
 author: Pham Ngoc Thanh
 date: 2022-06-16
 ---

--- a/Blockchain/Foundational topics/PoS.md
+++ b/Blockchain/Foundational topics/PoS.md
@@ -1,5 +1,5 @@
 ---
-tags: blockchain, foundational topics, PoS
+tags: blockchain, foundational-topics, PoS
 author: Pham Ngoc Thanh
 date: 2022-06-16
 ---

--- a/Blockchain/Foundational topics/Smart Contract.md
+++ b/Blockchain/Foundational topics/Smart Contract.md
@@ -1,5 +1,5 @@
 ---
-tags: blockchain, foundational topics, smart-contract
+tags: blockchain, foundational-topics, smart-contract
 author: Pham Ngoc Thanh
 date: 2022-06-16
 ---

--- a/Blockchain/Foundational topics/Topics.md
+++ b/Blockchain/Foundational topics/Topics.md
@@ -1,5 +1,5 @@
 ---
-tags: blockchain, foundational topics
+tags: blockchain, foundational-topics
 author: Pham Ngoc Thanh
 date: 2022-06-16
 ---

--- a/Blockchain/Foundational topics/Topics.md
+++ b/Blockchain/Foundational topics/Topics.md
@@ -1,6 +1,7 @@
 ---
 tags: blockchain, foundational topics
 author: Pham Ngoc Thanh
+date: 2022-06-16
 ---
 
 - Blocks

--- a/Blockchain/Liquidity pool.md
+++ b/Blockchain/Liquidity pool.md
@@ -1,6 +1,7 @@
 ---
 tags: blockchain, liquidity
 author: Hien Le
+date: 2022-03-24
 ---
 
 ## 1. What is a Liquidity Pool?

--- a/Blockchain/Multisign wallet.md
+++ b/Blockchain/Multisign wallet.md
@@ -1,6 +1,7 @@
 ---
 tags: blockchain, multisign-wallet
 author: Pham Ngoc Thanh
+date: 2022-08-10
 ---
 
 ![[multisign-wallet-hero-image.png]]

--- a/Blockchain/NFT Fractionalization.md
+++ b/Blockchain/NFT Fractionalization.md
@@ -1,6 +1,7 @@
 ---
 tags: blockchain, NFT
 author: Tran Khac Vy
+date: 2022-06-18
 ---
 
 ## What is a fractional NFT?

--- a/Design/UI History.md
+++ b/Design/UI History.md
@@ -1,6 +1,7 @@
 ---
 tags: ui, design, history
 author: Nam Bui
+date: 2022-08-05
 ---
 
 A good user interface should make it possible to complete any task quickly and with enjoyment. The user interface that you see on your MacOS or Windows PC has taken a long time to develop. This essay will briefly examine the changes in computer interface design over the last 30 years.

--- a/Design/UX Research/Triple S of UX in Web3.md
+++ b/Design/UX Research/Triple S of UX in Web3.md
@@ -1,6 +1,7 @@
 ---
 tags: ux, blockchain, web3
 author: Nam Bui
+date: 2022-08-05
 ---
 
 For most users in Web3 not excepting me, they are exposed to the tip of the iceberg which got them interested in space like Bitcoin, Defi, and NFT - these are simple terms that people know but when they dig deeper it's actually a whole lot term like "Gas Fees", "Private Key", "Public address",... It's not very user-friendly and people just give up halfway when you ask them about private key or others. So we want a familiar easy to understand way for users, I compose the Triple S of UX to make web3 accessible.

--- a/Design/What Screens Want.md
+++ b/Design/What Screens Want.md
@@ -1,6 +1,7 @@
 ---
 tags: ux, design, ui
 author: Cao Nguyen Huy Hoang
+date: 2022-06-28
 ---
 
 Frank Chimero has been branding for over 20 years in New York. Recently, he was creative director at FictiveKin.

--- a/Engineering/Concurrency in Javascript.md
+++ b/Engineering/Concurrency in Javascript.md
@@ -1,6 +1,7 @@
 ---
 tags: engineering, javascript, concurrency
 author: Hieu Phan
+date: 2022-08-26
 ---
 
 Javascript is a single-threaded programming language that has single-threaded at the runtime. It has a single call stack so it can do one thing simultaneously. JavaScript has a runtime model based on an **event loop**, which is responsible for executing the code, collecting and processing events, and executing queued sub-tasks. Javascript is a single-threaded, non-blocking asynchronous concurrent language. A JavaScript runtime uses a message queue, a list of messages to be processed. Each message has an associated function that gets called to handle the message.

--- a/Engineering/Frontend/Build polymorphic React components with Typescript.md
+++ b/Engineering/Frontend/Build polymorphic React components with Typescript.md
@@ -1,5 +1,5 @@
 ---
-tags: frontend, polymorphic component, reactjs, typescript, engineering/frontend
+tags: frontend, polymorphic-component, reactjs, typescript, engineering/frontend
 author: Tran Khac Vy
 date: 2022-09-26
 ---

--- a/Engineering/Frontend/CSS Container Queries.md
+++ b/Engineering/Frontend/CSS Container Queries.md
@@ -1,5 +1,5 @@
 ---
-tags: CSS, guides, responsive design, engineering/frontend
+tags: CSS, guides, responsive-design, engineering/frontend
 author: Tran Tien An
 date: 2022-09-02
 ---

--- a/Engineering/Frontend/HSL Color.md
+++ b/Engineering/Frontend/HSL Color.md
@@ -1,6 +1,6 @@
 ---
 tags: frontend, hsl, engineering/frontend
-author: Tran khac Vy
+author: Tran Khac Vy
 date: 2022-09-02
 ---
 

--- a/Engineering/Frontend/useEffect double calls in React 18.md
+++ b/Engineering/Frontend/useEffect double calls in React 18.md
@@ -1,6 +1,6 @@
 ---
 tags: engineering/frontend, frontend, react-18, react, hooks, useEffect
-author: T.Hoang Nam (Nigel)
+author: Tran Hoang Nam
 date: 2022-06-11
 ---
 

--- a/Engineering/Management/Stream-aligned team.md
+++ b/Engineering/Management/Stream-aligned team.md
@@ -1,6 +1,7 @@
 ---
 tags: engineering/management, team-topologies
 author: Pham Duc Thanh
+date: 2022-09-19
 ---
 
 A stream is the continuous flow of work aligned to a business domain or organizational capability. A stream requires clear goals and responsibilities so that multiple teams can coexist, each with their own flow of work.

--- a/Writing/Question tree.md
+++ b/Writing/Question tree.md
@@ -1,6 +1,7 @@
 ---
 tags: writing, consulting, research
 author: Nguyen Xuan Anh
+date: 2022-04-18
 ---
 
 ## What is a question tree?

--- a/Writing/State, Explain, Link.md
+++ b/Writing/State, Explain, Link.md
@@ -1,6 +1,7 @@
 ---
 tags: writing, english
 author: Nguyen Xuan Anh
+date: 2022-03-21
 ---
 
 # Introduction

--- a/_reports/Brainery Notes All Notes.md
+++ b/_reports/Brainery Notes All Notes.md
@@ -1,0 +1,34 @@
+## Engineering
+```dataview
+TABLE author, date, tags
+FROM #engineering
+WHERE author != NULL
+```
+
+## Writing
+```dataview
+TABLE author, date, tags
+FROM #writing
+WHERE author != NULL
+```
+
+## Design
+```dataview
+TABLE author, date, tags
+FROM #design
+WHERE author != NULL
+```
+
+## Communication
+```dataview
+TABLE author, date, tags
+FROM #communication 
+WHERE author != NULL
+```
+
+## Blockchain
+```dataview
+TABLE author, date, tags
+FROM #blockchain 
+WHERE author != NULL
+```

--- a/_reports/Brainery Notes All Notes.md
+++ b/_reports/Brainery Notes All Notes.md
@@ -1,34 +1,34 @@
 ## Engineering
 ```dataview
-TABLE author, date, tags
+TABLE author, date, "#" + regexreplace(tags, ", ", " #") as tags
 FROM #engineering
 WHERE author != NULL
 ```
 
 ## Writing
 ```dataview
-TABLE author, date, tags
+TABLE author, date, "#" + regexreplace(tags, ", ", " #") as tags
 FROM #writing
 WHERE author != NULL
 ```
 
 ## Design
 ```dataview
-TABLE author, date, tags
+TABLE author, date, "#" + regexreplace(tags, ", ", " #") as tags
 FROM #design
 WHERE author != NULL
 ```
 
 ## Communication
 ```dataview
-TABLE author, date, tags
+TABLE author, date, "#" + regexreplace(tags, ", ", " #") as tags
 FROM #communication 
 WHERE author != NULL
 ```
 
 ## Blockchain
 ```dataview
-TABLE author, date, tags
+TABLE author, date, "#" + regexreplace(tags, ", ", " #") as tags
 FROM #blockchain 
 WHERE author != NULL
 ```

--- a/_reports/Brainery Notes Report.md
+++ b/_reports/Brainery Notes Report.md
@@ -1,6 +1,6 @@
 ## Brainery submissions this month
 ```dataview
-TABLE author, date, tags
+TABLE author, date, "#" + regexreplace(tags, ", ", " #") as tags
 FROM #engineering OR #writing OR #design OR #communication OR #blockchain
 WHERE author != NULL
 	AND date.month = (date(today)).month
@@ -8,7 +8,7 @@ WHERE author != NULL
 
 ## Brainery submissions last month
 ```dataview
-TABLE author, date, tags
+TABLE author, date, "#" + regexreplace(tags, ", ", " #") as tags
 FROM #engineering OR #writing OR #design OR #communication OR #blockchain
 WHERE author != NULL
 	AND date.month = (date(today) - dur(1 month)).month

--- a/_reports/Brainery Notes Report.md
+++ b/_reports/Brainery Notes Report.md
@@ -1,0 +1,34 @@
+## Engineering
+```dataview
+TABLE author, date, tags
+FROM #engineering
+WHERE author != NULL
+```
+
+## Writing
+```dataview
+TABLE author, date, tags
+FROM #writing
+WHERE author != NULL
+```
+
+## Design
+```dataview
+TABLE author, date, tags
+FROM #design
+WHERE author != NULL
+```
+
+## Communication
+```dataview
+TABLE author, date, tags
+FROM #communication 
+WHERE author != NULL
+```
+
+## Blockchain
+```dataview
+TABLE author, date, tags
+FROM #blockchain 
+WHERE author != NULL
+```

--- a/_reports/Brainery Notes Report.md
+++ b/_reports/Brainery Notes Report.md
@@ -1,34 +1,15 @@
-## Engineering
+## Brainery submissions this month
 ```dataview
 TABLE author, date, tags
-FROM #engineering
+FROM #engineering OR #writing OR #design OR #communication OR #blockchain
 WHERE author != NULL
+	AND date.month = (date(today)).month
 ```
 
-## Writing
+## Brainery submissions last month
 ```dataview
 TABLE author, date, tags
-FROM #writing
+FROM #engineering OR #writing OR #design OR #communication OR #blockchain
 WHERE author != NULL
-```
-
-## Design
-```dataview
-TABLE author, date, tags
-FROM #design
-WHERE author != NULL
-```
-
-## Communication
-```dataview
-TABLE author, date, tags
-FROM #communication 
-WHERE author != NULL
-```
-
-## Blockchain
-```dataview
-TABLE author, date, tags
-FROM #blockchain 
-WHERE author != NULL
+	AND date.month = (date(today) - dur(1 month)).month
 ```

--- a/_reports/Brainery Notes Report.md
+++ b/_reports/Brainery Notes Report.md
@@ -1,15 +1,19 @@
 ## Brainery submissions this month
+
 ```dataview
-TABLE author, date, "#" + regexreplace(tags, ", ", " #") as tags
+TABLE rows.file.link as entries
 FROM #engineering OR #writing OR #design OR #communication OR #blockchain
 WHERE author != NULL
 	AND date.month = (date(today)).month
+GROUP BY author
 ```
+
 
 ## Brainery submissions last month
 ```dataview
-TABLE author, date, "#" + regexreplace(tags, ", ", " #") as tags
+TABLE rows.file.link as entries
 FROM #engineering OR #writing OR #design OR #communication OR #blockchain
 WHERE author != NULL
 	AND date.month = (date(today) - dur(1 month)).month
+GROUP BY author
 ```

--- a/_reports/Fleeting Notes All Notes.md
+++ b/_reports/Fleeting Notes All Notes.md
@@ -1,6 +1,6 @@
 ## Fleeting Notes
 ```dataview
-TABLE discord_id, discord_channel, date, tags
+TABLE discord_id, discord_channel, date, tags, file.symbol
 FROM "Ω Fleeting notes"
 WHERE discord_id != NULL
 ```

--- a/_reports/Fleeting Notes All Notes.md
+++ b/_reports/Fleeting Notes All Notes.md
@@ -1,6 +1,6 @@
 ## Fleeting Notes
 ```dataview
-TABLE discord_id, discord_channel, date, tags, file.symbol
+TABLE discord_id, discord_channel, date, "#" + regexreplace(tags, ", ", " #") as tags, file.symbol
 FROM "Ω Fleeting notes"
 WHERE discord_id != NULL
 ```

--- a/_reports/Fleeting Notes All Notes.md
+++ b/_reports/Fleeting Notes All Notes.md
@@ -1,6 +1,6 @@
 ## Fleeting Notes
 ```dataview
-TABLE discord_id, discord_channel, date, "#" + regexreplace(tags, ", ", " #") as tags, file.symbol
+TABLE discord_id, discord_channel, date, "#" + regexreplace(tags, ", ", " #") as tags
 FROM "Ω Fleeting notes"
 WHERE discord_id != NULL
 ```

--- a/_reports/Fleeting Notes Report.md
+++ b/_reports/Fleeting Notes Report.md
@@ -1,0 +1,15 @@
+## Fleeting Notes this month
+```dataview
+TABLE discord_id, discord_channel, date, "#" + regexreplace(tags, ", ", " #") as tags
+FROM "Ω Fleeting notes"
+WHERE discord_id != NULL
+	AND date.month = (date(today)).month
+```
+
+## Fleeting Notes last month
+```dataview
+TABLE discord_id, discord_channel, date, "#" + regexreplace(tags, ", ", " #") as tags
+FROM "Ω Fleeting notes"
+WHERE discord_id != NULL
+	AND date.month = (date(today) - dur(1 month)).month
+```

--- a/_reports/Fleeting Notes Report.md
+++ b/_reports/Fleeting Notes Report.md
@@ -1,0 +1,6 @@
+## Fleeting Notes
+```dataview
+TABLE discord_id, discord_channel, date, tags
+FROM "Ω Fleeting notes"
+WHERE discord_id != NULL
+```

--- a/_reports/Fleeting Notes Report.md
+++ b/_reports/Fleeting Notes Report.md
@@ -1,15 +1,17 @@
 ## Fleeting Notes this month
 ```dataview
-TABLE discord_id, discord_channel, date, "#" + regexreplace(tags, ", ", " #") as tags
+TABLE rows.file.link as entries
 FROM "Ω Fleeting notes"
 WHERE discord_id != NULL
 	AND date.month = (date(today)).month
+GROUP BY discord_id
 ```
 
 ## Fleeting Notes last month
 ```dataview
-TABLE discord_id, discord_channel, date, "#" + regexreplace(tags, ", ", " #") as tags
+TABLE rows.file.link as entries
 FROM "Ω Fleeting notes"
 WHERE discord_id != NULL
 	AND date.month = (date(today) - dur(1 month)).month
+GROUP BY discord_id
 ```


### PR DESCRIPTION
#### What's this PR do?

- [x] Adds dataview reports for fleeting notes
- [x] Adds dataview reports for brainery notes

This PR introduces an internal `_reports` folder to keep track of current brainery entries we've made so far that has an attributed `author` or `discord_id` frontmatter key. This may be used for aggregation collection of data in the future.

---

<img width="651" alt="image" src="https://user-images.githubusercontent.com/1130103/195592834-2f3c2070-6908-43df-b038-2b50e56c3b2d.png">

<img width="689" alt="image" src="https://user-images.githubusercontent.com/1130103/195592885-9ab74a91-8fb1-435b-b6fe-336887ab545d.png">


