### PR TITLE
feat: brainery submission discord

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,8 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-#exclude history folder in local vscode
+# exclude history folder in local vscode
 .history/*
+
+# exclude _env file
+_env.md

--- a/_templates/Run - Publish Entry to Discord.md
+++ b/_templates/Run - Publish Entry to Discord.md
@@ -1,0 +1,52 @@
+<%*
+const dv = this.app.plugins.plugins["dataview"].api;
+const page = dv.page("_env");
+
+const pageFields = Object.keys(page).filter(e => e !== "file");
+const field = await tp.system.suggester(items = pageFields, text_items = pageFields, throw_on_cancel=true, placeholder = "")
+const webhookURL = page[field];
+
+const contentNoFrontmatter = tp.file.content
+	.split("\n").slice(5).join("\n")
+const bareContent = contentNoFrontmatter
+	.replace(/^(#+(.*))$/gm, "\n")
+	.replace(/(\r\n|\n|\r)/gm, "")
+const description = bareContent.split(" ").slice(0, 35).join(' ') + "..."
+
+const currentPage = tp.file.folder();
+const title = tp.file.title;
+const braineryURL = "https://brain.d.foundation/" + encodeURIComponent(`${currentPage}/${title}`)
+const author = tp.frontmatter.author;
+const topic = tp.file.tags[0]
+const footerText = `Added at ${tp.date.now("MMMM D, YYYY h:mm A")} 🎉🎉🎉` ;
+
+const webhookBody = {
+	username: "Brainery",
+	avatar_url:  "https://cdn.discordapp.com/icons/462663954813157376/79ac3a24cf98b3c89be3902ca6fe168f.webp?size=96",
+	embeds: [
+		{
+			title,
+			url: braineryURL,
+			description,
+			fields: [
+			  { name: "Author", value: author, inline: true },
+			  { name: "Topic", value: topic, inline: true },
+			],
+			footer: {
+				text: footerText
+			}
+		}
+	]
+}
+
+const headers = {
+	"Content-Type": "application/json",
+}
+
+await requestUrl({
+	url: webhookURL,
+	method: "POST",
+	body: JSON.stringify(webhookBody),
+	headers,
+});
+%>

--- a/_templates/Run - Publish Entry to Discord.md
+++ b/_templates/Run - Publish Entry to Discord.md
@@ -2,7 +2,7 @@
 const dv = this.app.plugins.plugins["dataview"].api;
 const page = dv.page("_env");
 
-const pageFields = Object.keys(page).filter(e => e !== "file");
+const pageFields = Object.keys(page).filter(e => e.contains("discord_webhook"));
 const field = await tp.system.suggester(items = pageFields, text_items = pageFields, throw_on_cancel=true, placeholder = "")
 const webhookURL = page[field];
 


### PR DESCRIPTION
#### What's this PR do?

- [x] Migrates and implements [raycast extension brainery submission](https://github.com/dwarvesf/brainery-raycast-extension) with Templater and Dataview

Prior art included a method to do this through Obsidian Plugins. Since the code for this is not as complicated and the plugin itself may be deprecated in the future, I have chosen to implement it as a small script in Templater.

This script requires a file `_scripts/_env.md` with frontmatter containing your discord webhooks through a prefix/suffix `discord_webhook`:

<img width="699" alt="image" src="https://user-images.githubusercontent.com/1130103/204267588-ee02974f-2dc6-4b02-8c68-488781025357.png">

When you run the templater command, a prompt will include all `discord_webhook` frontmatter to select to which server/channel you wish to push to:
<img width="1075" alt="image" src="https://user-images.githubusercontent.com/1130103/204267906-cc29f773-2747-4f89-9ac9-5d6805e035b1.png">

<img width="1075" alt="image" src="https://user-images.githubusercontent.com/1130103/204267597-3deebfbc-dcb1-483b-b957-44a5c6f89928.png">
